### PR TITLE
Apply set_* scripts to the last profile created.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -31,8 +31,8 @@ repository].
 Installation and usage
 ----------------------
 
-Clone the [git repository], then run one of the scripts: set_light.sh or
-set_dark.sh.
+Clone the [git repository], create a new profile from gnome-terminal Menu, say
+"Solarized", and then run one of the scripts: set_light.sh or set_dark.sh.
 
     $ git clone git://github.com/sigurdga/gnome-terminal-colors-solarized.git
     $ cd gnome-terminal-colors-solarized
@@ -47,14 +47,10 @@ Specifying the profile to change
 --------------------------------
 
 And you can run them with a parameter, telling it which profile to modify. To
-change another profile than _Default_, this profile need to exist before you
+change another profile than the last created profile, this profile need to exist before you
 run the command. Now, at this point, it is not as easy as it should be, as the
-profile you created in the terminal will have another name on disk; the first
-one will be called Profile0, the second Profile1, etc. Ideally, I would like to
-make this step simpler, but I do not know how to script the creation of a new
-profile that will be visible in the graphical profile settings. Please give me
-a hint if you find a solution!
-
+profile you create in the terminal have another name on disk; the first
+one will be called Profile0, the second Profile1, etc.
 
 [Solarized homepage]:   http://ethanschoonover.com/solarized
 [Solarized repository]: https://github.com/altercation/solarized

--- a/set_dark.sh
+++ b/set_dark.sh
@@ -2,7 +2,11 @@
 
 dir=`dirname $0`
 
-PROFILE=${1:-Default}
+## LAST_PROFILE is set to the last created gnome-therminal profile
+LAST_PROFILE=`gconftool-2 -R /apps/gnome-terminal/profiles | grep Profile | \
+    awk 'BEGIN { FS = "/" } ; { print $5 }' | sed -e 's/://g' | sort | tail -n 1`
+
+PROFILE=${1:-${LAST_PROFILE}}
 
 # set palette
 gconftool-2 -s -t string /apps/gnome-terminal/profiles/$PROFILE/palette `cat $dir/colors/palette`

--- a/set_light.sh
+++ b/set_light.sh
@@ -2,7 +2,11 @@
 
 dir=`dirname $0`
 
-PROFILE=${1:-Default}
+## LAST_PROFILE is set to the last created gnome-therminal profile
+LAST_PROFILE=`gconftool-2 -R /apps/gnome-terminal/profiles | grep Profile | \
+    awk 'BEGIN { FS = "/" } ; { print $5 }' | sed -e 's/://g' | sort | tail -n 1`
+
+PROFILE=${1:-${LAST_PROFILE}}
 
 # set palette
 gconftool-2 -s -t string /apps/gnome-terminal/profiles/$PROFILE/palette `cat $dir/colors/palette`


### PR DESCRIPTION
This way the user has the possibility to use the script without the
need to dig in gconf-editor and without overriding the _Default_ profile.
