### PR TITLE
Make version processing handle w.x.y.z versions.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dir=$(dirname $0)
-gnomeVersion="$(echo `expr "$(gnome-terminal --version)" : '.*\(.\+[.].\+[.].\+\)$'`)"
+gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.\+[.].\+[.].\+\)$')"
 
 # newGnome=1 if the gnome-terminal version >= 3.8
 if [[ ("$(echo "$gnomeVersion" | cut -d"." -f1)" = "3" && \


### PR DESCRIPTION
Ubuntu 12.04.1 uses gnome-terminal 3.4.1.1; the previous regex (without the
space before the capturing parenthesis) captured 4.1.1, so the version check
set newGnome=1 and installation failed.  This change fixes the regex.

Also simplify the command, removing the unnecessary echo and backticks.
