### PR TITLE
Fix Gnome Terminal version detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dir=$(dirname $0)
-gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.\+[.].\+[.].\+\)$')"
+gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
 
 # newGnome=1 if the gnome-terminal version >= 3.8
 if [[ ("$(echo "$gnomeVersion" | cut -d"." -f1)" = "3" && \


### PR DESCRIPTION
(Discovered on OpenBSD.)

POSIX says that "Regular expression syntax shall be that defined in
XBD Basic Regular Expressions, [...]."

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html
