### PR TITLE
Lookup 'default' UUID value for you when specified

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -290,6 +290,9 @@ fi
 if [[ -n $scheme ]] && [[ -n $profile ]]
 then
   validate_scheme $scheme
+  if [ "$profile" == "default" ]; then
+    profile=":$(dconf read ${dconfdir}/default | sed 's/\o047//g')"
+  fi
   validate_profile $profile
   set_profile_colors $profile $scheme
 fi


### PR DESCRIPTION
Just installed Fedora 20 and am now running Gnome 3.8. I found it too annoying to look up the UUID of the default terminal session, so added support to lookup the UUID for you when you specify "-p default".  
