### PR TITLE
Quote profile names, so profile names with spaces work correctly.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,7 +401,7 @@ if [[ -n $scheme ]] && [[ -n $profile ]]
 then
   validate_scheme $scheme
   if [ "$newGnome" = "1" ]
-    then profile="$(get_uuid $profile)"
+    then profile="$(get_uuid "$profile")"
   fi
   validate_profile $profile
   set_profile_colors $profile $scheme

--- a/set_dark.sh
+++ b/set_dark.sh
@@ -4,4 +4,4 @@ dir=`dirname $0`
 
 PROFILE=${1:-Default}
 
-$dir/install.sh -s dark -p $PROFILE
+$dir/install.sh -s dark -p "$PROFILE"

--- a/set_light.sh
+++ b/set_light.sh
@@ -4,4 +4,4 @@ dir=`dirname $0`
 
 PROFILE=${1:-Default}
 
-$dir/install.sh -s light -p $PROFILE
+$dir/install.sh -s light -p "$PROFILE"


### PR DESCRIPTION
I had gnome-terminal profiles named "Stephen" and "Stephen Solarized", and running ./set_light.sh "Stephen Solarized" would edit the "Stephen" profile instead.

This adds some extra quoting to fix that.
