### PR TITLE
Find default profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ validate_scheme() {
 }
 
 set_profile_colors() {
-  local profile=$1
+  local profile=:$1
   local scheme=$2
   local scheme_dir=$dir/colors/$scheme
 

--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -47,8 +47,8 @@ get_profile_name() {
   # but it does priint error message to STDERR, and command substitution
   # only gets STDOUT which means nothing at this point.
   if [ "$newGnome" = "1" ]
-    then profile_name="$(gsettings get org.gnome.Terminal.Legacy.Profile:$dconfdir/":"$1/ visible-name | sed s/^\'// | \
-        sed s/\'$//)"
+    then profile_name="$(gsettings get org.gnome.Terminal.Legacy.Profile:$dconfdir/":"$1/ visible-name)"
+    profile_name="${profile_name:1:-1}"
   else
     profile_name=$(gconftool-2 -g $gconfdir/$1/visible_name)
   fi

--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -47,7 +47,7 @@ get_profile_name() {
   # but it does priint error message to STDERR, and command substitution
   # only gets STDOUT which means nothing at this point.
   if [ "$newGnome" = "1" ]
-    then profile_name="$(dconf read $dconfdir/$1/visible-name | sed s/^\'// | \
+    then profile_name="$(gsettings get org.gnome.Terminal.Legacy.Profile:$dconfdir/":"$1/ visible-name | sed s/^\'// | \
         sed s/\'$//)"
   else
     profile_name=$(gconftool-2 -g $gconfdir/$1/visible_name)

--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -6,7 +6,7 @@ dircolors_checked=false
 
 declare -a profiles
 if [ "$newGnome" = "1" ]
-  then profiles=($(dconf list $dconfdir/ | grep ^: | sed 's/\///g'))
+  then profiles=($(gsettings get org.gnome.Terminal.ProfilesList list | tr -d "[]\',"))
 else
   profiles=($(gconftool-2 -R $gconfdir | grep $gconfdir | cut -d/ -f5 |  \
            cut -d: -f1))
@@ -107,6 +107,6 @@ check_empty_profile() {
   if [ "$profiles" = "" ]
     then interactive_new_profile
     create_new_profile
-    profiles=($(dconf list $dconfdir/ | grep ^: | sed 's/\///g'))
+    profiles=($(gsettings get org.gnome.Terminal.ProfilesList list | tr -d "[]\',"))
   fi
 }


### PR DESCRIPTION
Fixes #47.
Targets only new Gnome (Gnome >= 3).

**Changes proposed:**
- `gsettings` to obtain profiles' identifiers and their names (instead of `dconf`)
- [Substring Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) to unquote the profile's name (instead of `sed`s)
- `tr` to extract each profile's identifier (instead of `grep` and `sed` combined)

# 1. Issues
* `install.sh` doesn't find the default profile if it's the only one available profile; needlessly asks to create new terminal profile.
* `install.sh --profile` doesn't work with the default profile's identifier as parameter.

## Steps to test
```bash
dconf reset -f /org/gnome/terminal/legacy/profiles:/
dconf read /org/gnome/terminal/legacy/profiles:/default # returns nothing
dconf read /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/visible-name # returns nothing
```

# 2. Solution
* Use `gsettings` command instead of `dconf` to get profiles' identifiers and their names.

## Steps to test
```bash
dconf reset -f /org/gnome/terminal/legacy/profiles:/
gsettings get org.gnome.Terminal.ProfilesList list # returns default profile's identifier
gsettings get org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/ visible-name # returns default profile's name
```
# 3. Screenshots

## Issue
![install.sh doesn't list the default profile with dconf](https://user-images.githubusercontent.com/31923722/30774199-0b45141a-a07f-11e7-8019-6938e6aefbeb.gif)

## Solution
![install.sh list the default profile with gsettings](https://user-images.githubusercontent.com/31923722/30774207-3087199e-a07f-11e7-8562-fca81575a97f.gif)

# 4. OS details
* Ubuntu 16.04.3 LTS
* GNOME Shell 3.18.5