### PR TITLE
Add ":" in profile comparision in get_uuid()

### DIFF
--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -26,7 +26,7 @@ get_uuid() {
   local profile_name=$1
   for i in ${!profiles[*]}
     do
-      if [[ "$(dconf read $dconfdir/${profiles[i]}/visible-name)" == \
+      if [[ "$(dconf read $dconfdir/:${profiles[i]}/visible-name)" == \
           "'$profile_name'" ]]
         then echo "${profiles[i]}"
         return 0


### PR DESCRIPTION
The `get_uuid(` routine forgot to add a colon in the dconf path to fetch a profile's `visible-name` (and it would thus always come up empty). This resulted in the `-p` parameter to `install.sh` not working.