### PR TITLE
delete the line for setting ${gnomeVersion}

### DIFF
--- a/src/profiles.sh
+++ b/src/profiles.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
 dircolors_checked=false
 
 


### PR DESCRIPTION
I agree with your, i review the code again. just delete the line of setting gnomeVersion at the beginning of src/profiles.sh. it's no use for the script. 
My screen shot of gnome-terminal is :
[wangshuwei@wangshuwei gnome-terminal-colors-solarized]$ gnome-terminal --version
GNOME Terminal 3.24.2 Using VTE version 0.48.3 +GNUTLS

thanks a lot .
